### PR TITLE
Reflect IETF AIPREF 2025-07-21 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The GitHub web interface offers many capabilities and can, accordingly, feel ove
 
 Using CC signals, a steward of a large collection of content can express a set of criteria that AI developers must meet. The criteria are organized around different dimensions of reciprocity, and are intended to drive meaningful, practical action. CC signals are designed to be interpretable by machines, as well as humans. To accomplish this, they build on [developing standards for expressing AI usage preferences][draft-vocab]. Those standards will include options for fully opting out, so no CC signal is needed to do so. CC signals are intended for use cases where someone wants to allow reuse, but with terms attached.
 
-[draft-vocab]: https://ietf-wg-aipref.github.io/drafts/draft-ietf-aipref-vocab.html
+[draft-vocab]: https://datatracker.ietf.org/doc/draft-ietf-aipref-vocab/
 
 
 ## CC signals
@@ -70,7 +70,7 @@ A **Declaring Party** is someone who specifies how a content collection should b
 
 ### The scope of machine uses addressed by the signal
 
-The Declaring Party applies CC signals to a set of standard categories that encompass machine use, from general categories to more specific categories, such as Text and Data Mining, AI Training, Generative AI Training, and AI Inference. In order to maximize global interoperability, these categories will not be defined by Creative Commons. Instead, they will be based upon global standards being developed by the Internet Engineering Task Force (IETF). The CC signals framework is designed to evolve as the standard categories are finalized. The selected category makes up the scope of what activity the tool is intended to address.
+The Declaring Party applies CC signals to a set of standard categories that encompass machine use, from general categories to more specific categories, such as Automated Processing, AI Training, Generative AI Training, AI Use, and Search. In order to maximize global interoperability, these categories will not be defined by Creative Commons. Instead, they will be based upon global standards being developed by the Internet Engineering Task Force (IETF). The CC signals framework is designed to evolve as the standard categories are finalized. The selected category makes up the scope of what activity the tool is intended to address.
 
 
 ### What signal is applied
@@ -146,12 +146,12 @@ We plan to create and release a set of "declarations" that explain the full pict
 
 ### Specification for extending the Vocabulary For Expressing AI Usage Preferences
 
-The CC signals extend the IETF draft [Vocabulary For Expressing AI Usage Preferences][draft-vocab]. It uses parameters (as defined by [RFC 9651: Structured Field Values for HTTP][rfc9651]). The IETF AI Preferences workgroup is initially defining two methods for attaching AI preferences to assets ([Indicating Preferences Regarding Content Usage][draft-attach]):
+The CC signals extend the IETF draft [Vocabulary For Expressing AI Usage Preferences][draft-vocab]. It uses parameters (as defined by [RFC 9651: Structured Field Values for HTTP][rfc9651]). The IETF AI Preferences workgroup is initially defining two methods for attaching AI preferences to assets ([Associating AI Usage Preferences With Content][draft-attach]):
 1. robots.txt ([RFC 9309: Robots Exclusion Protocol][rfc9309]) for location based preferences
 2. HTTP Content-Usage header for unit based preferences
 
 [draft-vocab]: https://datatracker.ietf.org/doc/draft-ietf-aipref-vocab/
-[draft-attach]: https://datatracker.ietf.org/doc/draft-it-aipref-attachment/
+[draft-attach]: https://datatracker.ietf.org/doc/draft-ietf-aipref-attach/
 [rfc9651]: https://www.rfc-editor.org/rfc/rfc9651.html
 [rfc9309]: https://www.rfc-editor.org/rfc/rfc9309.html
 
@@ -160,7 +160,7 @@ The CC signals extend the IETF draft [Vocabulary For Expressing AI Usage Prefere
 
 AI usage preferences with CC signals is defined in a content usage expression with the value including three components:
 ```
-ai=n;exceptions=cc-cr
+ai-use=n;exceptions=cc-cr
 ▲  ▲            ▲
 │  │            └ CC signal
 │  └ Preference
@@ -174,10 +174,10 @@ ai=n;exceptions=cc-cr
 
 ### Robots.txt example
 
-The following `robots.txt` excerpt example grants permission to all paths for all user agents with a usage preference of no for AI training unless credit is provided per the CC signal.
+The following `robots.txt` excerpt example grants permission to all paths for all user agents with a usage preference of no for AI use unless credit is provided per the CC signal.
 ```robots.txt
 User-Agent: *
-Content-Usage: ai=n;exceptions=cc-cr
+Content-Usage: ai-use=n;exceptions=cc-cr
 Allow: /
 ```
 
@@ -189,7 +189,7 @@ The following HTTP Content-Usage header example grants permission to the URL wit
 200 OK
 Date: Mon, 09 Jun 2025 12:42:03 UTC
 Content-Type: text/plain
-Content-Usage: genai=n;exceptions=cc-cr-ec
+Content-Usage: train-genai=n;exceptions=cc-cr-ec
 ```
 
 


### PR DESCRIPTION
## Description
Reflect IETF AIPREF 2025-07-21 changes

## Technical details
- [draft-ietf-aipref-vocab-02 - A Vocabulary For Expressing AI Usage Preferences](https://datatracker.ietf.org/doc/draft-ietf-aipref-vocab/)
  - Updated categories:
  - Automated Processing (`all`)
    - AI Training (`train-ai`)
      - Generative AI Training (`train-genai`)
    - AI Use (`ai-use`)
    - Search (`search`)
- [draft-ietf-aipref-attach-02 - Associating AI Usage Preferences With Content](https://www.ietf.org/archive/id/draft-ietf-aipref-attach-02.html)
  - Title change:
    -  ~~_Indicating Preferences Regarding Content Usage_~~ ➡️  _Associating AI Usage Preferences With Content_

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
